### PR TITLE
Add logger documentation and ignore "debug" level in production

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,3 +1,18 @@
+/*
+////////////////////////////////////////////////////
+//                   Logger                       //
+////////////////////////////////////////////////////
+
+Example:
+
+log.debug("recieved request", req)
+// => this will log the entire request
+
+Transports determine where the logs will be sent
+
+Selecting a level will mean the transport will ignore logs below that level
+*/
+
 var winston = require('winston');
 winston.emitErrs = true;
 
@@ -27,10 +42,14 @@ var logger = new(winston.Logger)({
       colorize: true,
       handleExceptions: true,
       json: false,
-      level: "info"
+      level: "debug"
     })
   ]
 });
 
+// if in production mode, don't log "debug" to console
+if (process.env.NODE_ENV === "production") {
+  logger.transports[0].level = "info";
+}
 
 module.exports = logger;


### PR DESCRIPTION
Will now ignore "debug" level logs on console when in production.

Also added documentation on the logger,