### PR TITLE
make a config object

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -1,0 +1,15 @@
+var allTheSettings = {
+  coinbaseApiKey: process.env.COINBASE_API_KEY,
+  coinbaseApiSec: process.env.COINBASE_API_SECRET,
+  coinbaseApiUri: process.env.COINBASE_API_URI,
+  coinbaseApiWallet: process.env.COINBASE_API_WALLET,
+  dbDb: process.env.DATABASE_DB,
+  dbHost: process.env.DATABASE_HOST,
+  dbPass: process.env.DATABASE_PASS,
+  dbUrl: process.env.DATABASE_URL,
+  dbUser: process.env.DATABASE_USER,
+  redisUrl: process.env.REDIS_URL,
+  secret: process.env.SECRET
+};
+
+module.exports = allTheSettings;


### PR DESCRIPTION
Bringing all references to environment variables through this file. Should make it easier for new people to understand which environment variables we've set, without hunting through all the files, and should make it easier for us to set custom strings during development.